### PR TITLE
Links to Platform.Cmd

### DIFF
--- a/architecture/effects/random.md
+++ b/architecture/effects/random.md
@@ -40,7 +40,7 @@ update msg model =
       (model, Cmd.none)
 ```
 
-Now the `update` function has the same overall shape as before, but the return type is a bit different. Instead of just giving back a `Model`, it produces both a `Model` and a command. The idea is: **we still want to step the model forward, but we also want to do some stuff.** In our case, we want to ask Elm to give us a random value. For now, I just fill it in with [`Cmd.none`](TODO) which means "I have no commands, do nothing." We will fill this in with the good stuff in phase two.
+Now the `update` function has the same overall shape as before, but the return type is a bit different. Instead of just giving back a `Model`, it produces both a `Model` and a [command](http://package.elm-lang.org/packages/elm-lang/core/latest/Platform-Cmd). The idea is: **we still want to step the model forward, but we also want to do some stuff.** In our case, we want to ask Elm to give us a random value. For now, I just fill it in with [`Cmd.none`](TODO) which means "I have no commands, do nothing." We will fill this in with the good stuff in phase two.
 
 Finally, I would create an `init` value like this:
 


### PR DESCRIPTION
Just as the mini-tutorial in http://package.elm-lang.org/packages/elm-lang/html/1.0.0/Html-App has links to these. When I saw Cmd.none I wanted to see the API. I see the TODO there. Is that for the same thing?
