### PR TITLE
fix possible typo in type annotation for viewValidation function

### DIFF
--- a/architecture/user_input/forms.md
+++ b/architecture/user_input/forms.md
@@ -63,7 +63,7 @@ view model =
     , viewValidation model
     ]
 
-viewValidation : Model -> Html msg
+viewValidation : Model -> Html Msg
 viewValidation model =
   let
     (color, message) =
@@ -130,7 +130,7 @@ It starts out normal: We create a `<div>` and put a couple `<input>` nodes in it
 But for the last child we do not directly use an HTML function. Instead we call the `viewValidation` function, passing in the current model.
 
 ```elm
-viewValidation : Model -> Html msg
+viewValidation : Model -> Html Msg
 viewValidation model =
   let
     (color, message) =


### PR DESCRIPTION
While reading through the guide I noticed the type annotation for `viewValidation` on http://guide.elm-lang.org/architecture/user_input/forms.html has `Msg` lowercased to `msg`. It compiles either way but is different from the convention of returning `Html Msg` as defined in the `view` function.

Not sure if this is actually a problem since I am new to Elm but wanted to bring it to your attention just in case. Thanks for making Elm! 