### PR TITLE
Records in python

### DIFF
--- a/core_language.md
+++ b/core_language.md
@@ -200,7 +200,7 @@ When it comes to making functions with records, you can do some pattern matching
 
 ```elm
 > under70 {age} = age < 70
-<function>
+<function> 
 
 > under70 bill
 True

--- a/core_language.md
+++ b/core_language.md
@@ -169,7 +169,7 @@ This can be quite handy, but when things start becoming more complicated, it is 
 
 ## Records
 
-A record is a set of key-value pairs, similar to objects in JavaScript or Python. You will find that they are extremely common and useful in Elm! Lets see some basic examples.
+A record is a set of key-value pairs, similar to objects in JavaScript and dictionaries in Python. You will find that they are extremely common and useful in Elm! Lets see some basic examples.
 
 
 ```elm
@@ -200,7 +200,7 @@ When it comes to making functions with records, you can do some pattern matching
 
 ```elm
 > under70 {age} = age < 70
-<function> 
+<function>
 
 > under70 bill
 True


### PR DESCRIPTION
Hi,
I'm a `Python` developer getting into `Elm`. I read the documentation and notice an error in the `Records` section at the `core language` page.
That way seems more logical and true to me.

Here is the [dictionaries page in python docs](https://docs.python.org/3/tutorial/datastructures.html#dictionaries).
Here is the discussion about this change in [Elm Google Group](https://groups.google.com/forum/#!topic/elm-discuss/5kAfW6ljJws).