### PR TITLE
use https for GETting giphy url so example works in Firefox

### DIFF
--- a/architecture/effects/http.md
+++ b/architecture/effects/http.md
@@ -95,7 +95,7 @@ getRandomGif : String -> Cmd Msg
 getRandomGif topic =
   let
     url =
-      "http://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=" ++ topic
+      "https://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=" ++ topic
   in
     Task.perform FetchFail FetchSucceed (Http.get decodeGifUrl url)
 


### PR DESCRIPTION
Giphy has CORS enabled which means images will fail to load in at least Firefox. Simply making sure the URL uses https (good practice) fixes this example :)

See https://github.com/elm-lang/elm-lang.org/pull/612 for the same fix in the examples. It would be good to advocate https in the guide to set a good example.