### PR TITLE
changing guide core_language 'like python' to 'like python3'

### DIFF
--- a/core_language.md
+++ b/core_language.md
@@ -44,7 +44,7 @@ Math looks normal too:
 20
 ```
 
-Unlike JavaScript, Elm makes a distinction between integers and floating point numbers. Just like Python, there is both floating point division `(/)` and integer division `(//)`.
+Unlike JavaScript, Elm makes a distinction between integers and floating point numbers. Just like Python 3, there is both floating point division `(/)` and integer division `(//)`.
 
 ```elm
 > 9 / 2


### PR DESCRIPTION
as python3 uses '/' for floating and '//' for integer, but in python2 this is not the case:

```
$ python3
Python 3.4.3 (default, Oct 14 2015, 20:28:29) 
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 9/2
4.5
>>> 9//2
4
```

```
$ python2
Python 2.7.6 (default, Jun 22 2015, 17:58:13) 
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> 9/2
4
>>> 9.0/2
4.5
```