### PR TITLE
Fix sample code for updating model in FetchSucceed

### DIFF
--- a/architecture/effects/http.md
+++ b/architecture/effects/http.md
@@ -78,7 +78,7 @@ update msg model =
       (model, getRandomGif model.topic)
 
     FetchSucceed newUrl ->
-      (Model model.topic newUrl, Cmd.none)
+      (Model model.gifUrl newUrl, Cmd.none)
 
     FetchFail _ ->
       (model, Cmd.none)


### PR DESCRIPTION
The sample code shows `model.topic` is updated when the text says we are updating `gifUrl`.