### PR TITLE
Fix typo in the JavaScript run-time error example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Notice that the `update` and `view` are entirely decoupled. You describe your HT
 
 Forget what you have heard about functional programming. Fancy words, weird ideas, bad tooling. Barf. Elm is about:
 
-  - No runtime errors in practice. No `null`. No `undefined` is not a function.
+  - No runtime errors in practice. No `null`. No `undefined is not a function`.
   - Friendly error messages that help you add features more quickly.
   - Well-architected code that *stays* well-architected as your app grows.
   - Automatically enforced semantic versioning for all Elm packages.


### PR DESCRIPTION
I am guessing this is what you originally meant :-)
