### PR TITLE
Remove backticks inside code block

### DIFF
--- a/error_handling/task.md
+++ b/error_handling/task.md
@@ -51,7 +51,7 @@ For example, maybe we want to GET stock quotes from a particular time. We could 
 
 ```elm
 getStockQuotes =
-  Time.now `andThen` \time ->
+  Time.now andThen \time ->
     Http.getString ("//www.example.com/stocks?time=" ++ toString time)
 ```
 


### PR DESCRIPTION
The backticks inside the code block are rendered incorrectly.
(The change at the end of the file is probably due to the github online editor adding a new line.)