### PR TITLE
Added note about potential file name conflicts in Random.md

### DIFF
--- a/architecture/effects/random.md
+++ b/architecture/effects/random.md
@@ -80,7 +80,7 @@ update msg model =
       (Model newFace, Cmd.none)
 ```
 
-There are two new things here. **First**, there is now a branch for `NewFace` messages. When a `NewFace` comes in, we just step the model forward and do nothing. **Second**, we have added a real command to the `Roll` branch. This uses a couple functions from [the `Random` library](http://package.elm-lang.org/packages/elm-lang/core/latest/Random). Most important is `Random.generate`:
+There are two new things here. **First**, there is now a branch for `NewFace` messages. When a `NewFace` comes in, we just step the model forward and do nothing. **Second**, we have added a real command to the `Roll` branch. This uses a couple functions from [the `Random` library](http://package.elm-lang.org/packages/elm-lang/core/latest/Random) (Note that you will get an error saying that Elm has found multiple modules named 'Random' if you name your file 'Random.elm'). Most important is `Random.generate`:
 
 ```elm
 Random.generate : (a -> msg) -> Random.Generator a -> Cmd msg


### PR DESCRIPTION
In the Random exercise, it is not explicitly written that the reader should not name his/her file as `Random.elm` as a naming collision error will occur when he/she tries to run `elm-make` or `elm-reactor`.

See https://github.com/elm-lang/elm-make/issues/104