### PR TITLE
Add missing String import

### DIFF
--- a/install.md
+++ b/install.md
@@ -62,6 +62,7 @@ $ elm-repl
 0.5 : Float
 > List.length [1,2,3,4]
 4 : Int
+> import String
 > String.reverse "stressed"
 "desserts" : String
 > :exit


### PR DESCRIPTION
Otherwise String.reverse will fail saying  "The qualifier String is not in
scope"