### PR TITLE
Minor update to 'undefined' error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Notice that the `update` and `view` are entirely decoupled. You describe your HT
 
 Forget what you have heard about functional programming. Fancy words, weird ideas, bad tooling. Barf. Elm is about:
 
-  - No runtime errors in practice. No `null`. No `undefined` is not a function.
+  - No runtime errors in practice. No `null`. No `undefined is not a function`.
   - Friendly error messages that help you add features more quickly.
   - Well-architected code that *stays* well-architected as your app grows.
   - Automatically enforced semantic versioning for all Elm packages.


### PR DESCRIPTION
The update more closely matches the actual message displayed by interpreters... Unless using the standalone `undefined` term was intentional, in which case, please ignore this PR.

Apologies for the erroneous update on line 61, that wasn't me, was just using the built-in GitHub editor, it seems to have gotten confused on that line :/