### PR TITLE
Remove unnecessary String import

### DIFF
--- a/architecture/user_input/text_fields.md
+++ b/architecture/user_input/text_fields.md
@@ -13,7 +13,6 @@ Again this is a pretty short program, so I have included the whole thing here. S
 import Html exposing (Html, Attribute, div, input, text)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
-import String
 
 
 main =


### PR DESCRIPTION
Removes an unnecessary String import form the example of the « Text Fields » section of the guide.

As [per documentation of the core module version 5.1.1](http://package.elm-lang.org/packages/elm-lang/core/5.1.1#default-imports), this module is part of the default imports.