### PR TITLE
Adding the actual url to the link "README"

### DIFF
--- a/reuse/more.md
+++ b/reuse/more.md
@@ -5,7 +5,7 @@ Right now this section gives a brief introduction to **reusable views**. Instead
   - [`evancz/elm-sortable-table`](https://github.com/evancz/elm-sortable-table)
   - [`thebritican/elm-autocomplete`](https://github.com/thebritican/elm-autocomplete)
 
-The [README]() of `elm-sortable-table` has some nice guidance on how to use APIs like these and why they are designed as they are. You can also watch the API design session where Greg and I figured out an API for `elm-autocomplete` here:
+The [README](https://github.com/evancz/elm-sortable-table/blob/master/README.md) of `elm-sortable-table` has some nice guidance on how to use APIs like these and why they are designed as they are. You can also watch the API design session where Greg and I figured out an API for `elm-autocomplete` here:
 
 {% youtube %}https://www.youtube.com/watch?v=KSuCYUqY058{% endyoutube %}
 


### PR DESCRIPTION
There are many ways to improve this book. Many of them require structural changes that would present concepts in a better order. These are quite hard to do, especially in a collaborative way if you want the book to come out coherent.

So the kind of PRs that are practical to handle include:

  - [ ] Fixing misspellings
  - [ ] Fixing broken links
  - [ ] Fixing code that is off for some reason, like a missing import or typo

More extreme cases are best reported and organized in a coherent way. From there, it is possible to do a revamp of the book that addresses readers concerns in a coherent way. Ultimately you also have to pick an audience, so it fundamentally cannot work for everyone. By logging who is confused and why, you can do better though!
