### PR TITLE
Fix up code examples to aid the reader in getting clean compiles with less frustration

### DIFF
--- a/architecture/effects/http.md
+++ b/architecture/effects/http.md
@@ -10,7 +10,7 @@ Now, I am going to assume you just read the randomness example. It (1) introduce
 
 ...
 
-Okay, so you read it now right? Good. Let's get started on our random gif fetcher!
+Okay, so you read it now, right? Good. Let's get started on our random gif fetcher!
 
 
 ## Phase One - The Bare Minimum
@@ -53,6 +53,8 @@ view model =
 ```
 
 For the model, I decided to track a `topic` so I know what kind of gifs to fetch. I do not want to hard code it to `"cats"`, and maybe later we will want to let the user decide the topic too. I also tracked the `gifUrl` which is a URL that points at some random gif.
+
+(The compiler should be reminding you to expose the `h2` and `img` functions from `Html`; you'll also need to `import Html.Attributes exposing (src)`.)
 
 Like in the randomness example, I just made dummy `init` and `update` functions. None of them actually produce any commands for now. The point is just to get something on screen!
 
@@ -108,9 +110,19 @@ decodeGifUrl =
   Decode.at ["data", "image_url"] Decode.string
 ```
 
-With that added, the "More" button actually goes and fetches a random gif. Check it out [here](http://elm-lang.org/examples/http)! But how does `getRandomGif` work exactly?
+With that added, the "More" button actually goes and fetches a random gif.
 
-It starts out simple, we define `url` to be some giphy endpoint for random gifs. Next we create an HTTP `request` with [`Http.get`](http://package.elm-lang.org/packages/elm-lang/http/latest/Http#get). Finally, we turn it into a command with [`Http.send`](http://package.elm-lang.org/packages/elm-lang/http/latest/Http#send). Let’s break those steps down a bit more:
+If you're following along, you'll need to `elm package install elm-lang/http` at this point. You'll also need the following import statements:
+
+```elm
+
+import Http exposing (get, send)
+import Json.Decode as Decode
+```
+
+Now our code should compile and run. Check it out [here](http://elm-lang.org/examples/http)! But how does `getRandomGif` work exactly?
+
+It starts out simple: we define `url` to be some giphy endpoint for random gifs. Next we create an HTTP `request` with [`Http.get`](http://package.elm-lang.org/packages/elm-lang/http/latest/Http#get). Finally, we turn it into a command with [`Http.send`](http://package.elm-lang.org/packages/elm-lang/http/latest/Http#send). Let’s break those steps down a bit more:
 
   - `Http.get : String -> Decode.Decoder value -> Http.Request value`
 
@@ -127,5 +139,7 @@ This has been a very quick introduction, but the key idea is that you must (1) c
 >   - Show a message explaining why the image didn't change when you get an [`Http.Error`](http://package.elm-lang.org/packages/elm-lang/http/latest/Http#Error).
 >   - Allow the user to modify the `topic` with a text field.
 >   - Allow the user to modify the `topic` with a drop down menu.
+>   - Replace our broken "waiting" image with a real one.
+>   - Send the command to fetch a gif from within our `init` function to avoid seeing the "waiting" image.
 
 

--- a/architecture/effects/random.md
+++ b/architecture/effects/random.md
@@ -54,7 +54,18 @@ init =
 
 Here we specify both the initial model and some commands we'd like to run immediately when the app starts. This is exactly the kind of stuff that `update` is producing now too.
 
-At this point, it is possible to wire it all up and take a look. You can click the `<button>`, but nothing happens. Let's fix that!
+To wire it all up, you'll need these lines at the top:
+```elm
+import Html exposing (Html, div, h1, text, button, program)
+import Html.Events exposing (onClick)
+
+
+main = program {init = init, update = update, view = view, subscriptions = subscriptions}
+```
+
+And for `subscriptions` you can simply return `Sub.none` for now.
+
+At this point, it is possible to load the program in a browser and take a look. You can click the `<button>`, but nothing happens. Let's fix that!
 
 
 ## Phase Two - Adding the Cool Stuff

--- a/architecture/effects/random.md
+++ b/architecture/effects/random.md
@@ -91,7 +91,7 @@ update msg model =
       (Model newFace, Cmd.none)
 ```
 
-There are two new things here. **First**, there is now a branch for `NewFace` messages. When a `NewFace` comes in, we just step the model forward and do nothing. **Second**, we have added a real command to the `Roll` branch. This uses a couple functions from [the `Random` library](http://package.elm-lang.org/packages/elm-lang/core/latest/Random). Most important is `Random.generate`:
+There are two new things here. **First**, there is now a branch for `NewFace` messages. When a `NewFace` comes in, we just step the model forward and do nothing. **Second**, we have added a real command to the `Roll` branch. This uses a couple functions from [the `Random` library](http://package.elm-lang.org/packages/elm-lang/core/latest/Random). (Don't forget to `import Random` near the top of your program.) Most important is `Random.generate`:
 
 ```elm
 Random.generate : (a -> msg) -> Random.Generator a -> Cmd msg

--- a/architecture/effects/time.md
+++ b/architecture/effects/time.md
@@ -78,6 +78,8 @@ view model =
 
 ```
 
+(If you're following along on your computer, you may need to `elm package install elm-lang/svg`.)
+
 There is nothing new in the `MODEL` or `UPDATE` sections. Same old stuff. The `view` function is kind of interesting. Instead of using HTML, we use the `Svg` library to draw some shapes. It works just like HTML though. You provide a list of attributes and a list of children for every node.
 
 The important thing comes in `SUBSCRIPTIONS` section. The `subscriptions` function takes in the model, and instead of returning `Sub.none` like in the examples we have seen so far, it gives back a real life subscription! In this case `Time.every`:
@@ -95,3 +97,4 @@ That is all there is to setting up a subscription! These messages will be fed to
 >
 >   - Add a button to pause the clock, turning the `Time` subscription off.
 >   - Make the clock look nicer. Add an hour and minute hand. Etc.
+>   - Send a command from `init` to make the first view of the clock show the correct time. (Hint: see [Task.perform](http://package.elm-lang.org/packages/elm-lang/core/5.1.1/Task#perform))

--- a/architecture/effects/web_sockets.md
+++ b/architecture/effects/web_sockets.md
@@ -87,6 +87,8 @@ viewMessage msg =
   div [] [ text msg ]
 ```
 
+(If you're following along with copy-n-paste, you probably need to `elm package install elm-lang/websocket`.)
+
 The interesting parts are probably the uses of `WebSocket.send` and `WebSocket.listen`.
 
 For simplicity we will target a simple server that just echos back whatever you type. So you will not be able to have the most exciting conversations in the basic version, but that is why we have exercises on these examples!

--- a/core_language.md
+++ b/core_language.md
@@ -154,8 +154,6 @@ Again, all elements of the list must have the same type.
 Tuples are another useful data structure. A tuple can hold a fixed number of values, and each value can have any type. A common use is if you need to return more than one value from a function. The following function gets a name and gives a message for the user:
 
 ```elm
-> import String
-
 > goodName name = \
 |   if String.length name <= 20 then \
 |     (True, "name accepted!") \

--- a/error_handling/result.md
+++ b/error_handling/result.md
@@ -19,8 +19,6 @@ type Result error value
 You have two constructors: `Err` to tag errors and `Ok` to tag successes. Let's see what happens when we actually use `String.toInt` in the REPL:
 
 ```elm
-> import String
-
 > String.toInt "128"
 Ok 128 : Result String Int
 

--- a/types/reading_types.md
+++ b/types/reading_types.md
@@ -48,7 +48,6 @@ In the first case, we have a `List` filled with `String` values. In the second, 
 Let's see the type of some functions:
 
 ```elm
-> import String
 > String.length
 <function> : String -> Int
 ```
@@ -190,7 +189,6 @@ So if you actually wrote down all the parentheses in the type, it would instead 
 It is the same with all functions in Elm:
 
 ```elm
-> import String
 > String.repeat
 <function> : Int -> String -> String
 ```

--- a/types/union_types.md
+++ b/types/union_types.md
@@ -68,7 +68,7 @@ keep visibility tasks =
       List.filter (\task -> task.complete) tasks
 ```
 
-The `case` is saying, look at the structure of `visibility`. If it is `All`, just give back all the tasks. If it is `Active`, keep only the tasks that are not complete. If it is `Completed`, keep only the tasks that are complete.
+The `case` is saying, look at the value of `visibility`. If it is `All`, just give back all the tasks. If it is `Active`, keep only the tasks that are not complete. If it is `Completed`, keep only the tasks that are complete.
 
 The cool thing about `case` expressions is that all the branches are checked by the compiler. This has some nice benefits:
 


### PR DESCRIPTION
There are many ways to improve this book. Many of them require structural changes that would present concepts in a better order. These are quite hard to do, especially in a collaborative way if you want the book to come out coherent.

So the kind of PRs that are practical to handle include:

  - [ ] Fixing misspellings
  - [ ] Fixing broken links
  - [X] Fixing code that is off for some reason, like a missing import or typo

More extreme cases are best reported and organized in a coherent way. From there, it is possible to do a revamp of the book that addresses readers concerns in a coherent way. Ultimately you also have to pick an audience, so it fundamentally cannot work for everyone. By logging who is confused and why, you can do better though!
