### PR TITLE
Remove irrelevant reference to Sub.none

### DIFF
--- a/architecture/effects/time.md
+++ b/architecture/effects/time.md
@@ -80,7 +80,7 @@ view model =
 
 There is nothing new in the `MODEL` or `UPDATE` sections. Same old stuff. The `view` function is kind of interesting. Instead of using HTML, we use the `Svg` library to draw some shapes. It works just like HTML though. You provide a list of attributes and a list of children for every node.
 
-The important thing comes in `SUBSCRIPTIONS` section. The `subscriptions` function takes in the model, and instead of returning `Sub.none` like in the examples we have seen so far, it gives back a real life subscription! In this case `Time.every`:
+The important thing comes in `SUBSCRIPTIONS` section. The `subscriptions` function takes in the model, and gives back a subscription. In this case `Time.every`:
 
 ```elm
 Time.every : Time -> (Time -> msg) -> Sub msg


### PR DESCRIPTION

This removes a piece of stale text from the [Time example](https://guide.elm-lang.org/architecture/effects/time.html).

The text was mentioning « instead of returning `Sub.none` like in the examples we have seen so far » but `Sub.none` is not being used in any of the currently published examples. 

