### PR TITLE
Add fullscreen embedding

### DIFF
--- a/interop/javascript.md
+++ b/interop/javascript.md
@@ -7,7 +7,7 @@ At some point your Elm program is probably going to need to talk to JavaScript. 
 This way we can have access to full power of JavaScript, the good and the bad, without giving up on all the things that are nice about Elm.
 
 
-## Step 1: Embed in HTML
+## Step 1: Explicitly Build Javascript
 
 Normally when you run the Elm compiler, it will give you an HTML file that sets everything up for you. So running this:
 
@@ -21,7 +21,16 @@ Will result in a `index.html` file that you can just open up and start using. To
 elm-make src/Main.elm --output=main.js
 ```
 
-Now the compiler will generate a JavaScript file that lets you initialize your program like this:
+Now the compiler will generate a JavaScript file that lets you customize your program initialization.
+
+
+## Step 2: Initialize Elm App
+
+There are two types of Elm app, embedded and fullscreen.
+
+### Embedded App
+
+To embed your program in a DOM node, initialize your program like this:
 
 ```html
 <div id="main"></div>
@@ -42,7 +51,7 @@ This is doing three important things:
 
 So now we can set Elm up in any `<div>` we want. So if you are using React, you can create a component that just sets this kind of thing up. If you are using Angular or Ember or something else, it should not be too crazy either. Just take over a `<div>`.
 
-### Fullscreen Embed in HTML
+### Fullscreen App
 
 If you don't need the app to be tied to a specific node, you can also get an elm app object by using the fullscreen method:
 
@@ -57,7 +66,7 @@ If you don't need the app to be tied to a specific node, you can also get an elm
 The next section gets into how to get your Elm and JavaScript code to communicate with each other in a nice way.
 
 
-## Step 2: Talk to JavaScript
+## Step 3: Talk to JavaScript
 
 There are two major ways for Elm and JavaScript to talk to each other: **ports** and **flags**.
 

--- a/interop/javascript.md
+++ b/interop/javascript.md
@@ -42,6 +42,17 @@ This is doing three important things:
 
 So now we can set Elm up in any `<div>` we want. So if you are using React, you can create a component that just sets this kind of thing up. If you are using Angular or Ember or something else, it should not be too crazy either. Just take over a `<div>`.
 
+### Fullscreen Embed in HTML
+
+If you don't need the app to be tied to a specific node, you can also get an elm app object by using the fullscreen method:
+
+```html
+<div id="main"></div>
+<script src="main.js"></script>
+<script>
+    var app = Elm.Main.fullscreen();
+```
+
 The next section gets into how to get your Elm and JavaScript code to communicate with each other in a nice way.
 
 

--- a/interop/javascript.md
+++ b/interop/javascript.md
@@ -51,6 +51,7 @@ If you don't need the app to be tied to a specific node, you can also get an elm
 <script src="main.js"></script>
 <script>
     var app = Elm.Main.fullscreen();
+</script>
 ```
 
 The next section gets into how to get your Elm and JavaScript code to communicate with each other in a nice way.

--- a/interop/javascript.md
+++ b/interop/javascript.md
@@ -63,7 +63,7 @@ If you don't need the app to be tied to a specific node, you can also get an elm
 </script>
 ```
 
-The next section gets into how to get your Elm and JavaScript code to communicate with each other in a nice way.
+The next section gets into how to get your Elm and JavaScript code to communicate with each other.
 
 
 ## Step 3: Talk to JavaScript


### PR DESCRIPTION
# Rationale
As a beginner, I was confused by the use of the elm app fullscreen initialization method before it was mentioned. In the current head, it is only described in a code snippet in the section on flags and never mentioned in the main text, but it is used in the section on ports. So, it seemed that ports required a different type of initialization than the one given in the interop section.

# Changes
Only minor changes were required to clarify this. I have split the "Embed in HTML" section into two sections: "Explicitly Compile Javascript" and "Initialize Elm App" and added fullscreen as one of the options for initialization.

I also included one unrelated minor edit. I removed an unneeded "in a nice way" to make the prose clearer and more compact.