### PR TITLE
Update link for IntelliJ plugin

### DIFF
--- a/install.md
+++ b/install.md
@@ -31,7 +31,7 @@ Using Elm is way nicer when you have a code editor to help you out. There are El
   * [Atom](https://atom.io/packages/language-elm)
   * [Brackets](https://github.com/lepinay/elm-brackets)
   * [Emacs](https://github.com/jcollard/elm-mode)
-  * [IntelliJ](https://github.com/durkiewicz/elm-plugin)
+  * [IntelliJ, WebStorm](https://github.com/klazuka/intellij-elm)
   * [Light Table](https://github.com/rundis/elm-light)
   * [Sublime Text](https://packagecontrol.io/packages/Elm%20Language%20Support)
   * [Vim](https://github.com/ElmCast/elm-vim)


### PR DESCRIPTION
The old IntelliJ plugin has been inactive for over a year now. And the original author [intends to remove it](https://github.com/durkiewicz/elm-plugin/issues/22#issuecomment-352651205) from the plugin repository in favor of the new plugin that I wrote.

The new plugin is actively developed and supports both 0.18 and 0.19.