### PR TITLE
Fix typo in route example - `topic/scuplture` to `topic/sculpture`

### DIFF
--- a/book/webapps/url_parsing.md
+++ b/book/webapps/url_parsing.md
@@ -15,7 +15,7 @@ Say we have an art website where the following addresses should be valid:
 
 - `/topic/architecture`
 - `/topic/painting`
-- `/topic/scuplture`
+- `/topic/sculpture`
 - `/blog/42`
 - `/blog/123`
 - `/blog/451`


### PR DESCRIPTION
Fix typo in route example - `topic/scuplture` to `topic/sculpture` 👍 