### PR TITLE
Update ports incoming example: replace msg by Msg

### DIFF
--- a/book/interop/ports.md
+++ b/book/interop/ports.md
@@ -84,7 +84,7 @@ type Msg
   = Searched String
   | Changed E.Value
 
-port activeUsers : (E.Value -> msg) -> Sub msg
+port activeUsers : (E.Value -> Msg) -> Sub Msg
 ```
 
 Again, the important line is the `port` declaration. It creates a `activeUsers` function, and if we subscribe to `activeUsers Changed`, we will get a `Msg` whenever folks send values in from JavaScript.


### PR DESCRIPTION
In this example we have defined a concrete Msg type. I think it makes sense to enforce that type with the port and replace `msg` by `Msg`. What do you think?

If you think it is better the way it is can you explain the rationale?

Thanks!