### PR TITLE
Add another exercise to time chapter

### DIFF
--- a/book/effects/time.md
+++ b/book/effects/time.md
@@ -178,6 +178,7 @@ Reading through the [`Task`][task] docs is the best way to understand that line.
 > **Exercises:**
 >
 > - Add a button to pause the clock, turning the `Time.every` subscription off.
+> - You might have noticed that it takes one second for current time to appear after page reload or unpause. Fix that!
 > - Make the digital clock look nicer. Maybe add some [`style`][style] attributes.
 > - Use [`elm/svg`][svg] to make an analog clock with a red second hand!
 


### PR DESCRIPTION
Just an idea for another exercise.
I've noticed that `Time.every` actually generates first message after interval, not at once. If this is intended behavior, avoiding it is a simple exercise that will push the user to figure out `Task` and `Time.now`.