### PR TITLE
fix missing square bracket in sample code for HTML.Keyed.node

### DIFF
--- a/book/optimization/keyed.md
+++ b/book/optimization/keyed.md
@@ -33,7 +33,7 @@ import Html.Lazy exposing (lazy)
 
 viewPresidents : List President -> Html msg
 viewPresidents presidents =
-  Keyed.node "ul" (List.map viewKeyedPresident presidents)
+  Keyed.node "ul" [] (List.map viewKeyedPresident presidents)
 
 viewKeyedPresident : President -> (String, Html msg)
 viewKeyedPresident president =


### PR DESCRIPTION

- Fixing typos in code

The original code :

```elm
Keyed.node "ul" (List.map viewKeyedPresident presidents)
```
should be:
```elm
Keyed.node "ul" [] (List.map viewKeyedPresident presidents)
```