### PR TITLE
Fix typo in code snippet from types/reading_types.md. Did not compile

### DIFF
--- a/book/types/reading_types.md
+++ b/book/types/reading_types.md
@@ -102,7 +102,7 @@ askVegeta powerLevel =
     "It's over 9000!!!"
 
   else
-    "It is " ++ toString powerLevel ++ "."
+    "It is " ++ String.fromInt powerLevel ++ "."
 ```
 
 People can make mistakes in type annotations, so what happens if they say the wrong thing? The compiler still figures out the type on its own, and it checks that your annotation matches the real answer. In other words, the compiler will always verify that all the annotations you add are correct!


### PR DESCRIPTION
toString does not compile with 0.19

>Detected errors in 1 module.
>-- NAMING ERROR --------------------------------------------------- scratch3.elm
>
>I cannot find a `toString` variable:
>
>6|     "It is " ++ toString powerLevel ++ "."
>                   ^^^^^^^^
>These names seem close though:
>
>    List.any
>    List.range
>    asin
>    ceiling
>
>Hint: Read <https://elm-lang.org/0.19.0/imports> to see how `import`
>declarations work in Elm.