### PR TITLE
Fixed typo in interop section

### DIFF
--- a/book/interop/README.md
+++ b/book/interop/README.md
@@ -75,6 +75,6 @@ var app = Elm.Main.init({
 
 We create an empty `<div>`. We want our Elm program to take over that node entirely. Maybe it is within a larger application, surrounded by tons of other stuff? That is fine!
 
-The `<script>` tag then inializes our Elm program. We grab the `node` we want to take over, and give it to `Elm.Main.init` which starts our program.
+The `<script>` tag then initializes our Elm program. We grab the `node` we want to take over, and give it to `Elm.Main.init` which starts our program.
 
 Now that we can embed Elm programs in an HTML document, it is time to start exploring the three interop options: flags, ports, and web components!


### PR DESCRIPTION
So the kind of PRs that are practical to handle include:

- Fixing misspellings
- Fixing broken links
- Fixing typos in code

Make your PR as small as possible.

Reviewing a typo is easy. Reviewing 10 typos is hard because 9 may be good. Now there is a bigger coordination overhead.

============================================

Noticed a typo in the interop section when I was going through the guide. This PR fixes the typo.