### PR TITLE
Fixed small typo

### DIFF
--- a/book/effects/json.md
+++ b/book/effects/json.md
@@ -133,7 +133,7 @@ This example is pretty similar to the last one:
 - `update` handles the `GotGif` message for whenever a new GIF is available. Whatever happens there, we do not have any additional commands. It also handles the `MorePlease` message when someone presses the button, issuing a command to get more random cats.
 - `view` shows you the cats!
 
-The main diferrence is in the `getRandomCatGif` definition. Instead of using `Http.expectString`, we have switched to `Http.expectJson`. What is the deal with that?
+The main difference is in the `getRandomCatGif` definition. Instead of using `Http.expectString`, we have switched to `Http.expectJson`. What is the deal with that?
 
 
 ## JSON


### PR DESCRIPTION
Fixed small typo "diferrence" => "difference".