### PR TITLE
Add mention about constructors for custom types

### DIFF
--- a/book/types/custom_types.md
+++ b/book/types/custom_types.md
@@ -63,6 +63,21 @@ type User
   | Anonymous
 ```
 
+With custom type definition we also get constructors for free. `Regular`, `Visitor` and `Anonymous` are all constructors returning `User` type as we can try in `elm repl`:
+
+```elm
+> type User \
+  = Regular String Int \
+  | Visitor String \
+  | Anonymous
+
+> Regular "Bourne" 33
+Regular "Bourne" 33 : User
+
+> Visitor "bond007"
+Visitor "bond007" : User
+```
+
 No problem! Let’s see some other examples now.
 
 


### PR DESCRIPTION
I couldn't understand for a long time how `Random.generate` typed as: `generate : (a -> msg) -> Generator a -> Cmd msg` could accept my custom type as first argument (typed as function `(a -> msg)`) until I have read from other resource about constructor functions for custom types.

I am suggesting add mention about these constructors into Custom Types section.