### PR TITLE
Fix Typo

### DIFF
--- a/book/types/custom_types.md
+++ b/book/types/custom_types.md
@@ -119,4 +119,4 @@ So you can start in the `Loading` state and then transition to `Failure` or `Suc
 Now we know how to create custom types, the next section will show how to use them!
 
 
-> **Note: Custom types are the most important feature in Elm.** They have a lot of depth, especially once you get in the habit of trying to model scenarios more precisely. I tried to share some of this depth in [Types as Sets](/appendix/types_as_sets.html) and [Types as Bits](/appendix/types_as_bits.html) in the appendix. I hope you find them helpful!
+> **Note: `Custom Types` is the most important feature in Elm.** They have a lot of depth, especially once you get in the habit of trying to model scenarios more precisely. I tried to share some of this depth in [Types as Sets](/appendix/types_as_sets.html) and [Types as Bits](/appendix/types_as_bits.html) in the appendix. I hope you find them helpful!


### PR DESCRIPTION
`Custom Types` refers to a singular feature, so `is` is the correct English.