### PR TITLE
Fix ambiguous wording in custom_types

### DIFF
--- a/book/types/custom_types.md
+++ b/book/types/custom_types.md
@@ -74,7 +74,7 @@ Another benefit of this approach is that each variant can have different associa
 ]
 {% endreplWithTypes %}
 
-Try defining a `Regular` visitor with a name and age ⬆️
+Try defining a `Regular` user with a name and age ⬆️
 
 We only added an age, but variants of a type can diverge quite dramatically. For example, maybe we want to add location for `Regular` users so we can suggest regional chat rooms. Add more associated data! Or maybe we want to have anonymous users. Add a third variant called `Anonymous`. Maybe we end up with:
 


### PR DESCRIPTION
The wording of `Regular` visitor is slightly confusing. I did understand without issue; but someone who is not a native English speaker may have some trouble with it. Not sure if "variant" would be a better fit; you seem to use "variant" and "user" somewhat interchangeably in this context L46 and L79.