### PR TITLE
Correction of code example to minify js output

### DIFF
--- a/book/optimization/asset_size.md
+++ b/book/optimization/asset_size.md
@@ -21,7 +21,7 @@ Putting those together, we can optimize `src/Main.elm` with two terminal command
 
 ```bash
 elm make src/Main.elm --optimize --output=elm.js
-uglifyjs elm.js --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=elm.min.js
+uglifyjs elm.js --compress pure_funcs=[\"F2\",\"F3\",\"F4\",\"F5\",\"F6\",\"F7\",\"F8\",\"F9\",\"A2\",\"A3\",\"A4\",\"A5\",\"A6\",\"A7\",\"A8\",\"A9\"],pure_getters,keep_fargs=false,unsafe_comps,unsafe | uglifyjs --mangle --output=elm.min.js
 ```
 
 After this you will have an `elm.js` and a smaller `elm.min.js` file!

--- a/book/optimization/asset_size.md
+++ b/book/optimization/asset_size.md
@@ -21,7 +21,7 @@ Putting those together, we can optimize `src/Main.elm` with two terminal command
 
 ```bash
 elm make src/Main.elm --optimize --output=elm.js
-uglifyjs elm.js --compress pure_funcs=[\"F2\",\"F3\",\"F4\",\"F5\",\"F6\",\"F7\",\"F8\",\"F9\",\"A2\",\"A3\",\"A4\",\"A5\",\"A6\",\"A7\",\"A8\",\"A9\"],pure_getters,keep_fargs=false,unsafe_comps,unsafe | uglifyjs --mangle --output=elm.min.js
+uglifyjs elm.js --compress pure_funcs=["F2","F3","F4","F5","F6","F7","F8","F9","A2","A3","A4","A5","A6","A7","A8","A9"],pure_getters,keep_fargs=false,unsafe_comps,unsafe | uglifyjs --mangle --output=elm.min.js
 ```
 
 After this you will have an `elm.js` and a smaller `elm.min.js` file!


### PR DESCRIPTION
Current code throws this error:
...```ERROR: `'pure_funcs=F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9,pure_getters,keep_fargs=false,unsafe_comps,unsafe'` is not a supported option
    at DefaultsError.get```...

Code was fixed based on this link:
[uglify-js docs](https://www.npmjs.com/package/uglify-js#compress-options)
