### PR TITLE
Edited optimize.sh based on shellcheck guidelines

### DIFF
--- a/book/optimization/asset_size.md
+++ b/book/optimization/asset_size.md
@@ -45,13 +45,13 @@ set -e
 js="elm.js"
 min="elm.min.js"
 
-elm make --optimize --output=$js $@
+elm make --optimize --output=$js "$@"
 
 uglifyjs $js --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=$min
 
-echo "Compiled size:$(cat $js | wc -c) bytes  ($js)"
-echo "Minified size:$(cat $min | wc -c) bytes  ($min)"
-echo "Gzipped size: $(cat $min | gzip -c | wc -c) bytes"
+echo "Compiled size:$(wc $js -c) bytes  ($js)"
+echo "Minified size:$(wc $min -c) bytes  ($min)"
+echo "Gzipped size: $(gzip $min -c | wc -c) bytes"
 ```
 
 Now if I run `./optimize.sh src/Main.elm` on my [TodoMVC](https://github.com/evancz/elm-todomvc) code, I see something like this in the terminal:


### PR DESCRIPTION
Quote `$@` to prevent re-splitting (SC2068)
Removed unnecessary `cat`s (SC2002)