### PR TITLE
clarify that Decode.map2 takes a constructor function as first argument

### DIFF
--- a/book/effects/json.md
+++ b/book/effects/json.md
@@ -273,7 +273,7 @@ That is all we needed for our HTTP example, but decoders can do more! For exampl
 map2 : (a -> b -> value) -> Decoder a -> Decoder b -> Decoder value
 ```
 
-This function takes in two decoders. It tries them both and combines their results. So now we can put together two different decoders:
+This function takes in a type constructor function and two decoders. It tries both decoders and combines their results using the type constructor. So now we can put together two different decoders:
 
 ```elm
 import Json.Decode exposing (Decoder, map2, field, string, int)
@@ -289,6 +289,8 @@ personDecoder =
   	(field "name" string)
   	(field "age" int)
 ```
+
+Here, since a type alias generates a constructor function for its type, the `Person` constructor is the first argument to map2, followed by the two decoders.
 
 So if we used `personDecoder` on `{ "name": "Tom", "age": 42 }` we would get out an Elm value like `Person "Tom" 42`.
 


### PR DESCRIPTION
I noticed that the section on `Json.Decode.map2` implies that map2 takes two decoders as its arguments, when in fact it takes three, the first one being a constructor function. This PR clarifies what the first argument to map2 is.

Yesterday I was working on decoding for an opaque type, and thus had to write my own constructor function in order to build a decoder. It was then that I realized the docs here are a little misleading, since they don't mention that the first argument has to be a constructor function.