### PR TITLE
Incorrect input in Interop / Flags

### DIFF
--- a/book/interop/flags.md
+++ b/book/interop/flags.md
@@ -85,13 +85,13 @@ The other supported types actually come from before we had figured out a way to 
 
 - `init : { x : Float, y : Float } -> ...`
   - `{ x: 3, y: 4, z: 50 }` => `{ x = 3, y = 4 }`
-  - `{ x: 3, name: "tom" }` => error
+  - `{ x: 3, name: "Tom" }` => error
   - `{ x: 360, y: "why?" }` => error
 
 - `init : (String, Int) -> ...`
-  - `['tom',42]` => `("Tom", 42)`
-  - `["sue",33]` => `("Sue", 33)`
-  - `["bob","4"]` => error
-  - `['joe',9,9]` => error
+  - `["Tom", 42]` => `("Tom", 42)`
+  - `["Sue", 33]` => `("Sue", 33)`
+  - `["Bob", "4"]` => error
+  - `["Joe", 9, 9]` => error
 
 Note that when one of the conversions goes wrong, **you get an error on the JS side!** We are taking the “fail fast” policy. Rather than the error making its way through Elm code, it is reported as soon as possible. This is another reason why people like to use `Json.Decode.Value` for flags. Instead of getting an error in JS, the weird value goes through a decoder, guaranteeing that you implement some sort of fallback behavior.


### PR DESCRIPTION
Letter case should not change when converting from JavaScript to Elm. 
P.S. Capitalized all names.