### PR TITLE
Fix link to main.js in webapp example for nested routes

### DIFF
--- a/book/webapps/README.md
+++ b/book/webapps/README.md
@@ -54,7 +54,7 @@ This will produce `main.js` which you can load from a custom HTML file like this
   <meta charset="UTF-8">
   <title>Main</title>
   <link rel="stylesheet" href="whatever-you-want.css">
-  <script src="main.js"></script>
+  <script src="/main.js"></script>
 </head>
 <body>
   <script>var app = Elm.Main.init();</script>


### PR DESCRIPTION
I came across an issue when using elm-live to serve my Elm app. If I refresh while visiting a nested route such as `localhost:8000/elm_rocks/new`, the relative uri to include `main.js` is incorrect as it becomes `localhost:8000/elm_rocks/main.js` which fails as `main.js` is served from the root path.

The error I got specifically complains about "X-Content-Type-Options: nosniff".

I'm hoping this small fix can help other Elm beginners use this wonderful language ❤️!