### PR TITLE
Fix link to Celsius conversion exercise

### DIFF
--- a/book/error_handling/maybe.md
+++ b/book/error_handling/maybe.md
@@ -48,7 +48,7 @@ Try calling `String.toFloat` with other strings to see what happens ⬆️
 
 Not all strings make sense as numbers, so this function models that explicitly. Can a string be turned into a float? Maybe! From there we can pattern match on the resulting data and continue as appropriate.
 
-> **Exercise:** I wrote a little program [here](https://ellie-app.com/3P9hcDhdsc5a1) that converts from Celsius to Fahrenheit. Try refactoring the `view` code in different ways. Can you put a red border around invalid input? Can you add more conversions? Fahrenheit to Celsius? Inches to Meters?
+> **Exercise:** I wrote a little program [here](https://ellie-app.com/8ZdSfFCpqrCa1) that converts from Celsius to Fahrenheit. Try refactoring the `view` code in different ways. Can you put a red border around invalid input? Can you add more conversions? Fahrenheit to Celsius? Inches to Meters?
 
 [toFloat]: https://package.elm-lang.org/packages/elm-lang/core/latest/String#toFloat
 


### PR DESCRIPTION
This PR changes the link for the Celsius to Fahrenheit conversion exercise to a version that compiles.

When I tried to load the exercise, I noticed that it leads to a page that has an error:

<img width="648" alt="image" src="https://user-images.githubusercontent.com/166258/83297717-13225a80-a1c1-11ea-98a7-c390ac622aee.png">

[The updated link](https://ellie-app.com/8ZdSfFCpqrCa1) is a version with the missing module name added so the page works on first load.