### PR TITLE
Fix build error caused by upstream change from uglify-js (#251)

### DIFF
--- a/repl/build.sh
+++ b/repl/build.sh
@@ -20,7 +20,7 @@ fi
 ./elm make src/Repl.elm --optimize --output=elm.js
 
 ./node_modules/.bin/uglifyjs elm.js --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" \
-  | ./node_modules/.bin/uglifyjs --mangle --output=assets/repl.js
+  | ./node_modules/.bin/uglifyjs --mangle --output assets/repl.js
 
 echo "Initial size: $(cat elm.js | wc -c) bytes"
 echo "Minified size:$(cat assets/repl.js | wc -c) bytes"


### PR DESCRIPTION
This patch was originally written for `elm-jp/guide` by @negiboudu san ([ref](https://github.com/elm-jp/guide/pull/194/commits/2d9d3e4376769fd20a3c6ea0be48dd4ee7bf2d13))