### PR TITLE
Tweak uglifyjs call

### DIFF
--- a/book/optimization/asset_size.md
+++ b/book/optimization/asset_size.md
@@ -21,7 +21,7 @@ Putting those together, we can optimize `src/Main.elm` with two terminal command
 
 ```bash
 elm make src/Main.elm --optimize --output=elm.js
-uglifyjs elm.js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output elm.min.js
+uglifyjs elm.js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,passes=2,unsafe_comps,unsafe' | uglifyjs --mangle --output elm.min.js
 ```
 
 After this you will have an `elm.js` and a smaller `elm.min.js` file!
@@ -47,7 +47,7 @@ min="elm.min.js"
 
 elm make --optimize --output=$js "$@"
 
-uglifyjs $js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output $min
+uglifyjs $js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,passes=2,unsafe_comps,unsafe' | uglifyjs --mangle --output $min
 
 echo "Compiled size:$(wc $js -c) bytes  ($js)"
 echo "Minified size:$(wc $min -c) bytes  ($min)"


### PR DESCRIPTION
- Remove `keep_fargs=false` because [it is false by default](https://github.com/mishoo/UglifyJS#compress-options).
- Use `passes=2` to [completely remove identity functions](https://github.com/mishoo/UglifyJS/issues/5003).