### PR TITLE
Fix incomplete example on Navigation

### DIFF
--- a/book/webapps/navigation.md
+++ b/book/webapps/navigation.md
@@ -153,6 +153,16 @@ view model =
 viewLink : String -> Html msg
 viewLink path =
   li [] [ a [ href path ] [ text path ] ]
+
+
+onUrlChange : Url.Url -> Msg
+onUrlChange url =
+    UrlChanged url
+
+
+onUrlRequest : Browser.UrlRequest -> Msg
+onUrlRequest urlRequest =
+    LinkClicked urlRequest
 ```
 
 The `update` function can handle either `LinkClicked` or `UrlChanged` messages. There is a lot of new stuff in the `LinkClicked` branch, so we will focus on that first!


### PR DESCRIPTION
The example for Web Apps / Navigation was missing implementations for onUrlChange and onUrlRequest, preventing it from compiling.

This PR adds the best implementation I could infer from how the code was described and the precedents the code set.