### PR TITLE
Add sentence clarifying elm init behavior

### DIFF
--- a/book/install/elm.md
+++ b/book/install/elm.md
@@ -39,6 +39,8 @@ Try running this command to create an `elm.json` file and a `src/` directory:
 - [`elm.json`](https://github.com/elm/compiler/blob/master/docs/elm.json/application.md) describes your project.
 - `src/` holds all of your Elm files.
 
+This won't create a new directory for your project, so if you want a directory to hold `elm.json` and `src`, you should create it before running `elm init`.
+
 Now try creating a file called `src/Main.elm` in your editor, and copying in the code from [the buttons example](https://elm-lang.org/examples/buttons).
 
 


### PR DESCRIPTION
Some `init` commands in various language ecosystems create the project directory; some don't. If you're familiar with a language that does create a directory (e.g. rust/cargo), then it might not be obvious that `elm init` doesn't.

This is a slightly larger change than the ones mentioned in the README as easy to accept pull requests, but also seems smaller than any of the current issues. Feel free to close this pull request and tell me to open an issue instead.